### PR TITLE
Use default WooCommerce status processing

### DIFF
--- a/src/Gateway/Blue_Media_Gateway.php
+++ b/src/Gateway/Blue_Media_Gateway.php
@@ -287,8 +287,8 @@ PlatformPluginVersion (wersja wtyczki zainstalowanej na platformie)
 				'description' => __( '',
 					'bm-woocommerce' ),
 				'type'        => 'select',
-				'options'     => wc_get_order_statuses(),
-				'default'     => 'wc-completed',
+                'options'     => array_merge(array('' => 'Auto'), wc_get_order_statuses()),
+                'default'     => '',
 			],
 			'wc_payment_status_on_bm_failure' => [
 				'title'       => __( 'Payment failure',
@@ -555,8 +555,7 @@ PlatformPluginVersion (wersja wtyczki zainstalowanej na platformie)
 					}
 
 					foreach ( $order_success_to_update as $wc_order ) {
-						$new_status = $this->get_option( 'wc_payment_status_on_bm_success', 'completed' );
-						$wc_order->set_status( $new_status );
+                        $wc_order->payment_complete();
 						$wc_order->add_order_note( 'PayBM ITN: paymentStatus SUCCESS' );
 						$wc_order->save();
 					}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -274,6 +274,20 @@ class Plugin extends Abstract_Ilabs_Plugin {
 			return;
 		}
 
+        add_filter( 'woocommerce_payment_complete_order_status',
+            function ( $status, $order_id, $order ) {
+                if ( 'bluemedia' === $order->get_payment_method() ) {
+                    if ( 'processing' === $status ) {
+                        $new_status = get_option( 'wc_payment_status_on_bm_success' );
+                        if( $new_status ) {
+                            return $new_status;
+                        }
+                    }
+                }
+                return $status;
+
+            }, 10, 3 );
+
 		add_filter( 'woocommerce_get_checkout_order_received_url',
 			function ( $return_url, $order ) {
 				$this->update_payment_cache( 'bm_order_received_url', $return_url );


### PR DESCRIPTION
Use `payment_complete` for success transactions.
Add  'Auto' for `wc_payment_status_on_bm_success` to leverage default WC status processing.

Default WC status processing moves an order to `completed` when there are only virtual downloadable products and leaves `processing` otherwise.